### PR TITLE
chore!: Use AndroidX over deprecated Android support library

### DIFF
--- a/android/src/main/java/com/nearit/connectivity/RNConnectivityStatusModule.java
+++ b/android/src/main/java/com/nearit/connectivity/RNConnectivityStatusModule.java
@@ -7,7 +7,7 @@ import android.content.Intent;
 import android.content.IntentFilter;
 import android.content.pm.PackageManager;
 import android.location.LocationManager;
-import android.support.v4.content.ContextCompat;
+import androidx.core.content.ContextCompat;
 
 import com.facebook.react.bridge.Promise;
 import com.facebook.react.bridge.ReactApplicationContext;


### PR DESCRIPTION
React Native version 0.60 makes it mandatory to use AndroidX.
Users of RN >= 0.60 currently need to run `jetify` in order for this
dependency to be usable.
The recommended upgrade path would be to switch libraries such as this
to AndroidX and release new major versions which deprecate RN < 0.60.
This commit includes the one change produced by running `jetify`
on the project.

References:

https://reactnative.dev/blog/2019/07/03/version-60#androidx-support
https://github.com/react-native-community/discussions-and-proposals/issues/129
https://developer.android.com/jetpack/androidx/migrate